### PR TITLE
lithium: Implement on boot TFA98xx calibration

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -52,5 +52,10 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/nfc/libnfc-brcm.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-brcm.conf \
     $(LOCAL_PATH)/nfc/libnfc-nxp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-nxp.conf
 
+# TFA calibration
+PRODUCT_PACKAGES += \
+    init.tfa.sh \
+    tinyplay
+
 # Inherit from msm8996-common
 $(call inherit-product, device/xiaomi/msm8996-common/msm8996.mk)

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -8,6 +8,9 @@ etc/acdbdata/Forte/Forte_Headset_cal.acdb
 etc/acdbdata/Forte/Forte_Speaker_cal.acdb
 etc/acdbdata/adsp_avs_config.acdb
 
+# Audio amplifier calibration sound
+etc/silence_short.wav
+
 # Audio amplifier firmware
 etc/firmware/tfa9891.cnt
 

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -3,6 +3,14 @@ LOCAL_PATH:= $(call my-dir)
 # Device config scripts
 
 include $(CLEAR_VARS)
+LOCAL_MODULE       := init.tfa.sh
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/init.tfa.sh
+LOCAL_MODULE_PATH  := $(TARGET_OUT_EXECUTABLES)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE       := usf_post_boot.sh
 LOCAL_MODULE_TAGS  := optional eng
 LOCAL_MODULE_CLASS := ETC

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -45,3 +45,13 @@ service usf-post-boot /system/bin/sh /system/etc/usf_post_boot.sh
 
 on property:init.svc.bootanim=stopped
     start usf-post-boot
+
+service tfa-sh /system/bin/init.tfa.sh /etc/silence_short.wav 15 1
+    class main
+    user system
+    group system
+    disabled
+    oneshot
+
+on property:sys.boot_completed=1
+    start tfa-sh

--- a/rootdir/etc/init.tfa.sh
+++ b/rootdir/etc/init.tfa.sh
@@ -1,0 +1,39 @@
+#!/system/bin/sh
+
+# $1: wave file to read
+# $2: volume(0-15)
+# $3: device for output
+#     0: current
+#     1: speaker
+#    12: earpiece
+#    -1: raw speaker
+#    -2: raw earpiece
+#    -3: headphone-48khz-16bit
+
+# tinyplay file.wav [-D card] [-d device] [-p period_size] [-n n_periods]
+# sample usage: playback_audio.sh 2000.wav  15 -1
+
+function enable_speaker {
+	echo "enabling speaker"
+	tinymix 'QUAT_MI2S_RX Audio Mixer MultiMedia1' 1
+	tinymix 'left Profile' 'music'
+}
+
+function disable_speaker {
+	echo "disabling speaker"
+	tinymix 'QUAT_MI2S_RX Audio Mixer MultiMedia1' 0
+}
+
+echo "Volume is ignored by this script for now"
+
+if [ "$3" -eq "1" -o "$3" -eq "-1" ]; then
+	enable_speaker
+fi
+
+tinyplay $1
+
+if [ "$3" -eq "1" -o "$3" -eq "-1" ]; then
+	disable_speaker
+fi
+
+exit 0


### PR DESCRIPTION
* TFA amplifier requires to play a calibration
  sound file on each boot otherwise it calibrates
  on the first played sound eg: unlock phone sound.

Change-Id: Ice91c29d14e30ed688007cffff56375b178106c2